### PR TITLE
Added instructions for working around the 401 Unauthorized error message

### DIFF
--- a/01-Setup and Getting started/Readme.md
+++ b/01-Setup and Getting started/Readme.md
@@ -132,6 +132,18 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ```
 The execution policy setting will be remembered and all future PS consoles opened in non-Admin (CurrentUser) mode will apply the 'RemoteSigned' execution policy.
 
+#### Error message: The remote server returned an error: (401) Unauthorized
+If you encounter the error message `Organization not found: Incorrect organization name or you do not have necessary permission to access the organization. InvalidOperation: The remote server returned an error: (401) Unauthorized`, this could mean that the logged in identity does not have access to the organization. 
+
+To ensure the tool use the correct identity, you can force the sign-in dialog to appear by setting a variable. 
+Here's how you can accomplish this: 
+
+```PowerShell
+$AzSKADOLoginUI = 1       ## Helps you ensure you log in with the correct identity
+Import-Module AzSK.ADO
+# > Run your commands again now.
+```
+
 #### How to register with PSGallery
 Use below command :
 ```PowerShell


### PR DESCRIPTION
When encountering a 401 Unauthorized, there's not much help to go on. 
It would be helpful to have this workaround documented in the FAQ of the getting started guide, as it would overcome the initial main blocker for many.